### PR TITLE
feat: create condition editor UI with dynamic parameter fields

### DIFF
--- a/src/components/editor/ConditionEditor.tsx
+++ b/src/components/editor/ConditionEditor.tsx
@@ -1,0 +1,341 @@
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { ConditionType, EventCondition } from "@/store/projectStore";
+
+const CONDITION_TYPES: { value: ConditionType; label: string }[] = [
+  { value: "switch", label: "Switch" },
+  { value: "variable", label: "Variable" },
+  { value: "hasItem", label: "Has Item" },
+  { value: "hasMonster", label: "Has Monster" },
+  { value: "partySize", label: "Party Size" },
+];
+
+const COMPARISON_OPS = [
+  { value: "==", label: "=" },
+  { value: "!=", label: "!=" },
+  { value: ">", label: ">" },
+  { value: "<", label: "<" },
+  { value: ">=", label: ">=" },
+  { value: "<=", label: "<=" },
+];
+
+interface ConditionEditorProps {
+  condition: EventCondition;
+  onUpdate: (updates: Partial<EventCondition>) => void;
+  onRemove: () => void;
+}
+
+export function ConditionEditor({
+  condition,
+  onUpdate,
+  onRemove,
+}: ConditionEditorProps) {
+  // Get human-readable condition text
+  const getConditionPreview = (): string => {
+    switch (condition.type) {
+      case "switch":
+        return `Switch [${condition.switchId || "?"}] is ${condition.switchValue ? "ON" : "OFF"}`;
+      case "variable":
+        return `Variable [${condition.variableId || "?"}] ${condition.variableOp || "=="} ${condition.variableValue ?? 0}`;
+      case "hasItem":
+        return `Has Item [${condition.itemId || "?"}]`;
+      case "hasMonster":
+        return condition.monsterId
+          ? `Has Monster [${condition.monsterId}]`
+          : "Has any Pokemon";
+      case "partySize":
+        return `Party Size ${condition.partySizeOp || "=="} ${condition.partySizeValue ?? 0}`;
+      default:
+        return "Unknown condition";
+    }
+  };
+
+  // Handle type change - reset parameters for new type
+  const handleTypeChange = (newType: ConditionType) => {
+    const baseUpdate: Partial<EventCondition> = { type: newType };
+
+    // Set default values for the new type
+    switch (newType) {
+      case "switch":
+        onUpdate({
+          ...baseUpdate,
+          switchId: "",
+          switchValue: true,
+          variableId: undefined,
+          variableOp: undefined,
+          variableValue: undefined,
+          itemId: undefined,
+          monsterId: undefined,
+          partySizeOp: undefined,
+          partySizeValue: undefined,
+        });
+        break;
+      case "variable":
+        onUpdate({
+          ...baseUpdate,
+          variableId: "",
+          variableOp: "==",
+          variableValue: 0,
+          switchId: undefined,
+          switchValue: undefined,
+          itemId: undefined,
+          monsterId: undefined,
+          partySizeOp: undefined,
+          partySizeValue: undefined,
+        });
+        break;
+      case "hasItem":
+        onUpdate({
+          ...baseUpdate,
+          itemId: "",
+          switchId: undefined,
+          switchValue: undefined,
+          variableId: undefined,
+          variableOp: undefined,
+          variableValue: undefined,
+          monsterId: undefined,
+          partySizeOp: undefined,
+          partySizeValue: undefined,
+        });
+        break;
+      case "hasMonster":
+        onUpdate({
+          ...baseUpdate,
+          monsterId: "",
+          switchId: undefined,
+          switchValue: undefined,
+          variableId: undefined,
+          variableOp: undefined,
+          variableValue: undefined,
+          itemId: undefined,
+          partySizeOp: undefined,
+          partySizeValue: undefined,
+        });
+        break;
+      case "partySize":
+        onUpdate({
+          ...baseUpdate,
+          partySizeOp: ">=",
+          partySizeValue: 1,
+          switchId: undefined,
+          switchValue: undefined,
+          variableId: undefined,
+          variableOp: undefined,
+          variableValue: undefined,
+          itemId: undefined,
+          monsterId: undefined,
+        });
+        break;
+    }
+  };
+
+  // Render parameter fields based on condition type
+  const renderParameters = () => {
+    switch (condition.type) {
+      case "switch":
+        return (
+          <div className="space-y-2">
+            <div className="space-y-1">
+              <Label className="text-xs">Switch ID</Label>
+              <Input
+                className="h-7 text-xs"
+                placeholder="e.g., intro_complete"
+                value={condition.switchId || ""}
+                onChange={(e) => onUpdate({ switchId: e.target.value })}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Value</Label>
+              <Select
+                value={condition.switchValue ? "true" : "false"}
+                onValueChange={(v) => onUpdate({ switchValue: v === "true" })}
+              >
+                <SelectTrigger className="h-7 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="true">ON</SelectItem>
+                  <SelectItem value="false">OFF</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        );
+
+      case "variable":
+        return (
+          <div className="space-y-2">
+            <div className="space-y-1">
+              <Label className="text-xs">Variable ID</Label>
+              <Input
+                className="h-7 text-xs"
+                placeholder="e.g., player_level"
+                value={condition.variableId || ""}
+                onChange={(e) => onUpdate({ variableId: e.target.value })}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1">
+                <Label className="text-xs">Operator</Label>
+                <Select
+                  value={condition.variableOp || "=="}
+                  onValueChange={(v) =>
+                    onUpdate({
+                      variableOp: v as EventCondition["variableOp"],
+                    })
+                  }
+                >
+                  <SelectTrigger className="h-7 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {COMPARISON_OPS.map((op) => (
+                      <SelectItem key={op.value} value={op.value}>
+                        {op.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Value</Label>
+                <Input
+                  type="number"
+                  className="h-7 text-xs"
+                  value={condition.variableValue ?? 0}
+                  onChange={(e) =>
+                    onUpdate({ variableValue: parseInt(e.target.value, 10) || 0 })
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        );
+
+      case "hasItem":
+        return (
+          <div className="space-y-2">
+            <div className="space-y-1">
+              <Label className="text-xs">Item ID</Label>
+              <Input
+                className="h-7 text-xs"
+                placeholder="e.g., potion"
+                value={condition.itemId || ""}
+                onChange={(e) => onUpdate({ itemId: e.target.value })}
+              />
+            </div>
+          </div>
+        );
+
+      case "hasMonster":
+        return (
+          <div className="space-y-2">
+            <div className="space-y-1">
+              <Label className="text-xs">Monster ID (empty = any)</Label>
+              <Input
+                className="h-7 text-xs"
+                placeholder="e.g., pikachu (or empty for any)"
+                value={condition.monsterId || ""}
+                onChange={(e) => onUpdate({ monsterId: e.target.value })}
+              />
+            </div>
+          </div>
+        );
+
+      case "partySize":
+        return (
+          <div className="space-y-2">
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1">
+                <Label className="text-xs">Operator</Label>
+                <Select
+                  value={condition.partySizeOp || ">="}
+                  onValueChange={(v) =>
+                    onUpdate({
+                      partySizeOp: v as EventCondition["partySizeOp"],
+                    })
+                  }
+                >
+                  <SelectTrigger className="h-7 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {COMPARISON_OPS.map((op) => (
+                      <SelectItem key={op.value} value={op.value}>
+                        {op.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Size</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={6}
+                  className="h-7 text-xs"
+                  value={condition.partySizeValue ?? 1}
+                  onChange={(e) =>
+                    onUpdate({
+                      partySizeValue: parseInt(e.target.value, 10) || 0,
+                    })
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="p-2 bg-muted/50 rounded border space-y-2">
+      {/* Header with type selector and delete button */}
+      <div className="flex items-center gap-2">
+        <Select value={condition.type} onValueChange={handleTypeChange}>
+          <SelectTrigger className="h-7 flex-1 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {CONDITION_TYPES.map((ct) => (
+              <SelectItem key={ct.value} value={ct.value}>
+                {ct.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+          onClick={onRemove}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+
+      {/* Dynamic parameter fields */}
+      {renderParameters()}
+
+      {/* Preview */}
+      <div className="pt-1 border-t">
+        <p className="text-xs text-muted-foreground italic">
+          {getConditionPreview()}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/EventEditor.tsx
+++ b/src/components/editor/EventEditor.tsx
@@ -2,7 +2,6 @@ import { Plus, Trash2, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Select,
   SelectContent,
@@ -12,10 +11,10 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ConditionEditor } from "@/components/editor/ConditionEditor";
 import { useEditorStore } from "@/store/editorStore";
 import {
   type CommandType,
-  type ConditionType,
   type EventCommand,
   type EventCondition,
   type EventPage,
@@ -43,14 +42,6 @@ const TRIGGERS: { value: EventTrigger; label: string; description: string }[] =
     },
   ];
 
-const CONDITION_TYPES: { value: ConditionType; label: string }[] = [
-  { value: "switch", label: "Switch" },
-  { value: "variable", label: "Variable" },
-  { value: "hasItem", label: "Has Item" },
-  { value: "hasPokemon", label: "Has Pokemon" },
-  { value: "partySize", label: "Party Size" },
-];
-
 const COMMAND_TYPES: { value: CommandType; label: string }[] = [
   { value: "showMessage", label: "Show Message" },
   { value: "showChoices", label: "Show Choices" },
@@ -58,7 +49,7 @@ const COMMAND_TYPES: { value: CommandType; label: string }[] = [
   { value: "setVariable", label: "Set Variable" },
   { value: "conditional", label: "Conditional Branch" },
   { value: "teleport", label: "Teleport" },
-  { value: "givePokemon", label: "Give Pokemon" },
+  { value: "giveMonster", label: "Give Monster" },
 ];
 
 interface EventEditorProps {
@@ -193,24 +184,6 @@ export function EventEditor({ event, mapId }: EventEditorProps) {
     });
   };
 
-  // Get human-readable condition text
-  const getConditionText = (condition: EventCondition): string => {
-    switch (condition.type) {
-      case "switch":
-        return `Switch [${condition.switchId || "?"}] is ${condition.switchValue ? "ON" : "OFF"}`;
-      case "variable":
-        return `Variable [${condition.variableId || "?"}] ${condition.variableOp || "=="} ${condition.variableValue ?? 0}`;
-      case "hasItem":
-        return `Has Item [${condition.itemId || "?"}]`;
-      case "hasPokemon":
-        return `Has Pokemon [${condition.pokemonId || "any"}]`;
-      case "partySize":
-        return `Party Size ${condition.partySizeOp || "=="} ${condition.partySizeValue ?? 0}`;
-      default:
-        return "Unknown condition";
-    }
-  };
-
   // Get human-readable command text
   const getCommandText = (command: EventCommand): string => {
     switch (command.type) {
@@ -226,8 +199,8 @@ export function EventEditor({ event, mapId }: EventEditorProps) {
         return "Conditional Branch";
       case "teleport":
         return `Teleport to (${command.teleportX ?? "?"}, ${command.teleportY ?? "?"})`;
-      case "givePokemon":
-        return `Give Pokemon [${command.pokemonId || "?"}] Lv.${command.pokemonLevel ?? 5}`;
+      case "giveMonster":
+        return `Give Monster [${command.monsterId || "?"}] Lv.${command.monsterLevel ?? 5}`;
       default:
         return "Unknown command";
     }
@@ -417,45 +390,18 @@ export function EventEditor({ event, mapId }: EventEditorProps) {
                         No conditions (always active)
                       </p>
                     ) : (
-                      <div className="space-y-1">
+                      <div className="space-y-2">
                         {page.conditions.map((condition) => (
-                          <div
+                          <ConditionEditor
                             key={condition.id}
-                            className="flex items-center gap-1 p-1 bg-muted/50 rounded text-xs"
-                          >
-                            <Select
-                              value={condition.type}
-                              onValueChange={(value: ConditionType) =>
-                                handleUpdateCondition(page.id, condition.id, {
-                                  type: value,
-                                })
-                              }
-                            >
-                              <SelectTrigger className="h-6 w-24 text-xs">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {CONDITION_TYPES.map((ct) => (
-                                  <SelectItem key={ct.value} value={ct.value}>
-                                    {ct.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <span className="flex-1 text-xs truncate">
-                              {getConditionText(condition)}
-                            </span>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="h-5 w-5 p-0"
-                              onClick={() =>
-                                handleRemoveCondition(page.id, condition.id)
-                              }
-                            >
-                              <Trash2 className="h-3 w-3" />
-                            </Button>
-                          </div>
+                            condition={condition}
+                            onUpdate={(updates) =>
+                              handleUpdateCondition(page.id, condition.id, updates)
+                            }
+                            onRemove={() =>
+                              handleRemoveCondition(page.id, condition.id)
+                            }
+                          />
                         ))}
                       </div>
                     )}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -53,7 +53,7 @@ export type ConditionType =
   | "switch"
   | "variable"
   | "hasItem"
-  | "hasPokemon"
+  | "hasMonster"
   | "partySize";
 
 export interface EventCondition {
@@ -66,7 +66,7 @@ export interface EventCondition {
   variableOp?: "==" | "!=" | ">" | "<" | ">=" | "<=";
   variableValue?: number;
   itemId?: string;
-  pokemonId?: string;
+  monsterId?: string;
   partySizeOp?: "==" | "!=" | ">" | "<" | ">=" | "<=";
   partySizeValue?: number;
 }
@@ -79,7 +79,7 @@ export type CommandType =
   | "setVariable"
   | "conditional"
   | "teleport"
-  | "givePokemon";
+  | "giveMonster";
 
 export interface EventCommand {
   id: string;
@@ -99,8 +99,8 @@ export interface EventCommand {
   teleportMapId?: string;
   teleportX?: number;
   teleportY?: number;
-  pokemonId?: string;
-  pokemonLevel?: number;
+  monsterId?: string;
+  monsterLevel?: number;
 }
 
 export interface EventPage {


### PR DESCRIPTION
## Summary
- Creates ConditionEditor component with type-specific parameter fields
- Integrates into EventEditor replacing inline condition display
- Renames all pokemon references to monster throughout the codebase

## Condition Types
Each condition type has its own parameter fields:
- **Switch**: Switch ID input + ON/OFF toggle
- **Variable**: Variable ID + comparison operator + numeric value
- **Has Item**: Item ID input
- **Has Monster**: Monster ID input (empty = any monster)
- **Party Size**: Comparison operator + numeric value

## Features
- Dynamic parameter fields change based on selected condition type
- Human-readable condition preview text
- Type selector dropdown for easy switching
- Delete button for each condition

## Test plan
- [ ] Create an event and select it
- [ ] Add a condition using the + button
- [ ] Change condition type and verify fields update
- [ ] Fill in switch condition fields and verify preview
- [ ] Fill in variable condition fields and verify preview
- [ ] Fill in hasItem condition fields and verify preview
- [ ] Fill in hasMonster condition fields and verify preview
- [ ] Fill in partySize condition fields and verify preview
- [ ] Delete a condition using the trash button

Closes #19